### PR TITLE
Fixed a notice on certain situations

### DIFF
--- a/term-pages.php
+++ b/term-pages.php
@@ -176,7 +176,7 @@ class Term_Pages {
 	 */
 	function custom_page_query( $query ) {
 		//check if we have a taxonomy
-		if ( ( $query->is_category() ) || ( $query->is_tax() ) || ( $query->is_tag() ) ) {
+		if ( $query->is_main_query() && ( $query->is_category() ) || ( $query->is_tax() ) || ( $query->is_tag() ) ) {
 
 			$term = get_queried_object();
 			$term_id = $term->term_id;


### PR DESCRIPTION
the custom_page_query "thinks" that $query is the query for the current page - BUT it's also called for other queries from other plugins. Hence get_queried_object is not guaranteed to return a term.

Fixed by adding a new is_main_query() condition. is_main_query() should only return true for the query corresponding to the current page.

I did not fully test this change - please have a look before accepting the pull request and publishing it.